### PR TITLE
Updates for Dart 2.0 core library changes (wave 2.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,8 @@
 
 * Updates to support Dart 2.0 core library changes (wave
   2.2). See [issue 31847][sdk#31847] for details.
-  
-  [sdk#31847]: https://github.com/dart-lang/sdk/issues/31847
 
+  [sdk#31847]: https://github.com/dart-lang/sdk/issues/31847
 
 ## 0.9.0+3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 0.9.0+4
+
+* Updates to support Dart 2.0 core library changes (wave
+  2.2). See [issue 31847][sdk#31847] for details.
+  
+  [sdk#31847]: https://github.com/dart-lang/sdk/issues/31847
+
+
 ## 0.9.0+3
 
 * Code cleanup.

--- a/lib/src/utf_stream.dart
+++ b/lib/src/utf_stream.dart
@@ -10,8 +10,8 @@ import 'constants.dart';
 import 'util.dart';
 
 // TODO(floitsch): make this transformer reusable.
-abstract class _StringDecoder
-    implements StreamTransformer<List<int>, String>, EventSink<List<int>> {
+abstract class _StringDecoder extends StreamTransformerBase<List<int>, String>
+    implements EventSink<List<int>> {
   List<int> _carry;
   List<int> _buffer;
   int _replacementChar;
@@ -52,6 +52,7 @@ abstract class _StringDecoder
           }
           return null;
         }
+
         int consumed = _processBytes(getNext);
         if (consumed > 0) {
           goodChars = _buffer.length;
@@ -108,6 +109,7 @@ abstract class _StringDecoder
         throw new ArgumentError('Invalid codepoint');
       }
     }
+
     if (char < 0) error();
     if (char >= 0xD800 && char <= 0xDFFF) error();
     if (char > 0x10FFFF) error();
@@ -176,8 +178,8 @@ class Utf8DecoderTransformer extends _StringDecoder {
   }
 }
 
-abstract class _StringEncoder
-    implements StreamTransformer<String, List<int>>, EventSink<String> {
+abstract class _StringEncoder extends StreamTransformerBase<String, List<int>>
+    implements EventSink<String> {
   EventSink<List<int>> _outSink;
 
   Stream<List<int>> bind(Stream<String> stream) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,10 +1,10 @@
 name: utf
-version: 0.9.0+3
+version: 0.9.0+4
 author: Dart Team <misc@dartlang.org>
 description: >
  Provides common operations for manipulating Unicode sequences
 homepage: https://www.github.com/dart-lang/utf
 environment:
-  sdk: '>=1.0.0 <2.0.0'
+  sdk: '>=2.0.0-dev.20.0 <2.0.0'
 dev_dependencies:
   test: ^0.12.0


### PR DESCRIPTION
Change classes that implement `StreamTransformer` to extend `StreamTransformerBase`.